### PR TITLE
Removed warnings due to sprintf in old gromacs code.

### DIFF
--- a/src/gromacs/fileio/gmxfio.cpp
+++ b/src/gromacs/fileio/gmxfio.cpp
@@ -560,12 +560,9 @@ static int gmx_fio_int_get_file_position(t_fileio *fio, gmx_off_t *offset)
     /* Flush the file, so we are sure it is written */
     if (gmx_fio_int_flush(fio))
     {
-        char buf[STRLEN];
-        sprintf(
-                buf,
-                "Cannot write file '%s'; maybe you are out of disk space?",
-                fio->fn);
-        gmx_file(buf);
+        auto buf = gmx::formatString("Cannot write file '%s'; maybe you are out of disk space?",
+                                     fio->fn);
+        gmx_file(buf.c_str());
     }
 
     /* We cannot count on XDR being able to write 64-bit integers,

--- a/src/gromacs/fileio/readinp.cpp
+++ b/src/gromacs/fileio/readinp.cpp
@@ -345,14 +345,14 @@ int get_eint(std::vector<t_inpfile> *inp, const char *name, int def,
              warninp_t wi)
 {
     std::vector<t_inpfile> &inpRef = *inp;
-    char                    buf[32], *ptr, warn_buf[STRLEN];
+    char                   *ptr;
 
     int                     ii = get_einp(inp, name);
 
     if (ii == -1)
     {
-        sprintf(buf, "%d", def);
-        inpRef.back().value_.assign(buf);
+        auto buf = gmx::formatString("%d", def);
+        inpRef.back().value_.assign(buf.c_str());
 
         return def;
     }
@@ -361,8 +361,8 @@ int get_eint(std::vector<t_inpfile> *inp, const char *name, int def,
         int ret = std::strtol(inpRef[ii].value_.c_str(), &ptr, 10);
         if (*ptr != '\0')
         {
-            sprintf(warn_buf, "Right hand side '%s' for parameter '%s' in parameter file is not an integer value\n", inpRef[ii].value_.c_str(), inpRef[ii].name_.c_str());
-            warning_error(wi, warn_buf);
+            auto warn_buf = gmx::formatString("Right hand side '%s' for parameter '%s' in parameter file is not an integer value\n", inpRef[ii].value_.c_str(), inpRef[ii].name_.c_str());
+            warning_error(wi, warn_buf.c_str());
         }
 
         return ret;
@@ -381,14 +381,14 @@ int64_t get_eint64(std::vector<t_inpfile> *inp,
                    warninp_t wi)
 {
     std::vector<t_inpfile> &inpRef = *inp;
-    char                    buf[32], *ptr, warn_buf[STRLEN];
+    char                   *ptr;
 
     int                     ii = get_einp(inp, name);
 
     if (ii == -1)
     {
-        sprintf(buf, "%" PRId64, def);
-        inpRef.back().value_.assign(buf);
+        auto buf = gmx::formatString("%" PRId64, def);
+        inpRef.back().value_.assign(buf.c_str());
 
         return def;
     }
@@ -397,8 +397,8 @@ int64_t get_eint64(std::vector<t_inpfile> *inp,
         int64_t ret = str_to_int64_t(inpRef[ii].value_.c_str(), &ptr);
         if (*ptr != '\0')
         {
-            sprintf(warn_buf, "Right hand side '%s' for parameter '%s' in parameter file is not an integer value\n", inpRef[ii].value_.c_str(), inpRef[ii].name_.c_str());
-            warning_error(wi, warn_buf);
+            auto warn_buf = gmx::formatString("Right hand side '%s' for parameter '%s' in parameter file is not an integer value\n", inpRef[ii].value_.c_str(), inpRef[ii].name_.c_str());
+            warning_error(wi, warn_buf.c_str());
         }
 
         return ret;
@@ -417,14 +417,14 @@ double get_ereal(std::vector<t_inpfile> *inp, const char *name, double def,
                  warninp_t wi)
 {
     std::vector<t_inpfile> &inpRef = *inp;
-    char                    buf[32], *ptr, warn_buf[STRLEN];
+    char                   *ptr;
 
     int                     ii = get_einp(inp, name);
 
     if (ii == -1)
     {
-        sprintf(buf, "%g", def);
-        inpRef.back().value_.assign(buf);
+        auto buf = gmx::formatString("%g", def);
+        inpRef.back().value_.assign(buf.c_str());
 
         return def;
     }
@@ -433,8 +433,8 @@ double get_ereal(std::vector<t_inpfile> *inp, const char *name, double def,
         double ret = strtod(inpRef[ii].value_.c_str(), &ptr);
         if (*ptr != '\0')
         {
-            sprintf(warn_buf, "Right hand side '%s' for parameter '%s' in parameter file is not a real value\n", inpRef[ii].value_.c_str(), inpRef[ii].name_.c_str());
-            warning_error(wi, warn_buf);
+            auto warn_buf = gmx::formatString("Right hand side '%s' for parameter '%s' in parameter file is not a real value\n", inpRef[ii].value_.c_str(), inpRef[ii].name_.c_str());
+            warning_error(wi, warn_buf.c_str());
         }
 
         return ret;
@@ -451,7 +451,6 @@ double get_ereal(std::vector<t_inpfile> *inp, const std::string &name, double de
 const char *get_estr(std::vector<t_inpfile> *inp, const char *name, const char *def)
 {
     std::vector<t_inpfile> &inpRef = *inp;
-    char                    buf[32];
 
     int                     ii = get_einp(inp, name);
 
@@ -459,8 +458,7 @@ const char *get_estr(std::vector<t_inpfile> *inp, const char *name, const char *
     {
         if (def)
         {
-            sprintf(buf, "%s", def);
-            inpRef.back().value_.assign(buf);
+            inpRef.back().value_.assign(def);
         }
         else
         {
@@ -485,9 +483,6 @@ int get_eeenum(std::vector<t_inpfile> *inp, const char *name, const char **defs,
                warninp_t wi)
 {
     std::vector<t_inpfile> &inpRef = *inp;
-    int                     n      = 0;
-    char                    buf[STRLEN];
-
     int                     ii = get_einp(inp, name);
 
     if (ii == -1)
@@ -507,22 +502,22 @@ int get_eeenum(std::vector<t_inpfile> *inp, const char *name, const char **defs,
 
     if (defs[i] == nullptr)
     {
-        n += sprintf(buf, "Invalid enum '%s' for variable %s, using '%s'\n",
-                     inpRef[ii].value_.c_str(), name, defs[0]);
-        n += sprintf(buf+n, "Next time use one of:");
+        auto buf = gmx::formatString("Invalid enum '%s' for variable %s, using '%s'\n",
+                                     inpRef[ii].value_.c_str(), name, defs[0]);
+        buf.append("Next time use one of:");
         int j  = 0;
         while (defs[j])
         {
-            n += sprintf(buf+n, " '%s'", defs[j]);
+            buf.append(gmx::formatString(" '%s'", defs[j]));
             j++;
         }
         if (wi != nullptr)
         {
-            warning_error(wi, buf);
+            warning_error(wi, buf.c_str());
         }
         else
         {
-            fprintf(stderr, "%s\n", buf);
+            fprintf(stderr, "%s\n", buf.c_str());
         }
 
         inpRef[ii].value_ = gmx_strdup(defs[0]);

--- a/src/gromacs/fileio/trrio.cpp
+++ b/src/gromacs/fileio/trrio.cpp
@@ -96,7 +96,6 @@ do_trr_frame_header(t_fileio *fio, bool bRead, gmx_trr_header_t *sh, gmx_bool *b
     const int       magicValue = 1993;
     int             magic      = magicValue;
     static gmx_bool bFirst     = TRUE;
-    char            buf[256];
 
     *bOK = TRUE;
 
@@ -116,6 +115,7 @@ do_trr_frame_header(t_fileio *fio, bool bRead, gmx_trr_header_t *sh, gmx_bool *b
 
     if (bRead)
     {
+        char buf[STRLEN];
         *bOK = *bOK && gmx_fio_do_string(fio, buf);
         if (bFirst)
         {
@@ -124,7 +124,8 @@ do_trr_frame_header(t_fileio *fio, bool bRead, gmx_trr_header_t *sh, gmx_bool *b
     }
     else
     {
-        sprintf(buf, "GMX_trn_file");
+        char buf[STRLEN];
+        snprintf(buf, STRLEN-1, "GMX_trn_file");
         *bOK = *bOK && gmx_fio_do_string(fio, buf);
     }
     *bOK = *bOK && gmx_fio_do_int(fio, sh->ir_size);

--- a/src/gromacs/fileio/trxio.cpp
+++ b/src/gromacs/fileio/trxio.cpp
@@ -273,7 +273,6 @@ void set_trxframe_ePBC(t_trxframe *fr, int ePBC)
 int write_trxframe_indexed(t_trxstatus *status, const t_trxframe *fr, int nind,
                            const int *ind, gmx_conect gc)
 {
-    char  title[STRLEN];
     rvec *xout = nullptr, *vout = nullptr, *fout = nullptr;
     int   i, ftp = -1;
 
@@ -330,7 +329,7 @@ int write_trxframe_indexed(t_trxstatus *status, const t_trxframe *fr, int nind,
         default:
             break;
     }
-
+    auto title = gmx::formatString("frame t= %.3f", fr->time);
     switch (ftp)
     {
         case efTRR:
@@ -346,21 +345,19 @@ int write_trxframe_indexed(t_trxstatus *status, const t_trxframe *fr, int nind,
                 gmx_fatal(FARGS, "Can not write a %s file without atom names",
                           ftp2ext(ftp));
             }
-            sprintf(title, "frame t= %.3f", fr->time);
             if (ftp == efGRO)
             {
-                write_hconf_indexed_p(gmx_fio_getfp(status->fio), title, fr->atoms, nind, ind,
+                write_hconf_indexed_p(gmx_fio_getfp(status->fio), title.c_str(), fr->atoms, nind, ind,
                                       fr->x, fr->bV ? fr->v : nullptr, fr->box);
             }
             else
             {
-                write_pdbfile_indexed(gmx_fio_getfp(status->fio), title, fr->atoms,
+                write_pdbfile_indexed(gmx_fio_getfp(status->fio), title.c_str(), fr->atoms,
                                       fr->x, -1, fr->box, ' ', fr->step, nind, ind, gc, TRUE, FALSE);
             }
             break;
         case efG96:
-            sprintf(title, "frame t= %.3f", fr->time);
-            write_g96_conf(gmx_fio_getfp(status->fio), title, fr, nind, ind);
+            write_g96_conf(gmx_fio_getfp(status->fio), title.c_str(), fr, nind, ind);
             break;
         default:
             gmx_fatal(FARGS, "Sorry, write_trxframe_indexed can not write %s",
@@ -389,8 +386,6 @@ int write_trxframe_indexed(t_trxstatus *status, const t_trxframe *fr, int nind,
 
 int write_trxframe(t_trxstatus *status, t_trxframe *fr, gmx_conect gc)
 {
-    char title[STRLEN];
-
     switch (gmx_fio_getftp(status->fio))
     {
         case efTRR:
@@ -403,7 +398,7 @@ int write_trxframe(t_trxstatus *status, t_trxframe *fr, gmx_conect gc)
             }
             break;
     }
-
+    auto title = gmx::formatString("frame t= %.3f", fr->time);
     switch (gmx_fio_getftp(status->fio))
     {
         case efTRR:
@@ -419,21 +414,20 @@ int write_trxframe(t_trxstatus *status, t_trxframe *fr, gmx_conect gc)
                 gmx_fatal(FARGS, "Can not write a %s file without atom names",
                           ftp2ext(gmx_fio_getftp(status->fio)));
             }
-            sprintf(title, "frame t= %.3f", fr->time);
             if (gmx_fio_getftp(status->fio) == efGRO)
             {
-                write_hconf_p(gmx_fio_getfp(status->fio), title, fr->atoms,
+                write_hconf_p(gmx_fio_getfp(status->fio), title.c_str(), fr->atoms,
                               fr->x, fr->bV ? fr->v : nullptr, fr->box);
             }
             else
             {
-                write_pdbfile(gmx_fio_getfp(status->fio), title,
+                write_pdbfile(gmx_fio_getfp(status->fio), title.c_str(),
                               fr->atoms, fr->x, fr->bPBC ? fr->ePBC : -1, fr->box,
                               ' ', fr->step, gc, TRUE);
             }
             break;
         case efG96:
-            write_g96_conf(gmx_fio_getfp(status->fio), title, fr, -1, nullptr);
+            write_g96_conf(gmx_fio_getfp(status->fio), title.c_str(), fr, -1, nullptr);
             break;
         default:
             gmx_fatal(FARGS, "Sorry, write_trxframe can not write %s",

--- a/src/gromacs/fileio/warninp.cpp
+++ b/src/gromacs/fileio/warninp.cpp
@@ -246,20 +246,14 @@ void free_warning(warninp_t wi)
 
 void _too_few(warninp_t wi, const char *fn, int line)
 {
-    char buf[STRLEN];
-
-    sprintf(buf,
-            "Too few parameters on line (source file %s, line %d)",
-            fn, line);
-    warning(wi, buf);
+    auto buf = gmx::formatString("Too few parameters on line (source file %s, line %d)",
+                                 fn, line);
+    warning(wi, buf.c_str());
 }
 
 void _incorrect_n_param(warninp_t wi, const char *fn, int line)
 {
-    char buf[STRLEN];
-
-    sprintf(buf,
-            "Incorrect number of parameters on line (source file %s, line %d)",
-            fn, line);
-    warning(wi, buf);
+    auto buf = gmx::formatString("Incorrect number of parameters on line (source file %s, line %d)",
+                                 fn, line);
+    warning(wi, buf.c_str());
 }

--- a/src/gromacs/fileio/xvgr.cpp
+++ b/src/gromacs/fileio/xvgr.cpp
@@ -142,10 +142,10 @@ static char *xvgrstr(const std::string &gmx, const gmx_output_env_t *oenv,
                 switch (xvgf)
                 {
                     case exvgXMGRACE:
-                        sprintf(buf+b, "%s", "\\f{}");
+                        snprintf(buf+b, buflen-b-1, "%s", "\\f{}");
                         break;
                     case exvgXMGR:
-                        sprintf(buf+b, "%s", "\\4");
+                        snprintf(buf+b, buflen-b-1, "%s", "\\4");
                         break;
                     default:
                         buf[b] = '\0';
@@ -160,10 +160,10 @@ static char *xvgrstr(const std::string &gmx, const gmx_output_env_t *oenv,
                 switch (xvgf)
                 {
                     case exvgXMGRACE:
-                        sprintf(buf+b, "%s", "\\x");
+                        snprintf(buf+b, buflen-b-1, "%s", "\\x");
                         break;
                     case exvgXMGR:
-                        sprintf(buf+b, "%s", "\\8");
+                        snprintf(buf+b, buflen-b-1, "%s", "\\8");
                         break;
                     default:
                         buf[b] = '\0';
@@ -191,10 +191,10 @@ static char *xvgrstr(const std::string &gmx, const gmx_output_env_t *oenv,
                     switch (xvgf)
                     {
                         case exvgXMGRACE:
-                            sprintf(buf+b, "%s%c%s", "\\x", c, "\\f{}");
+                            snprintf(buf+b, buflen-b-1, "%s%c%s", "\\x", c, "\\f{}");
                             break;
                         case exvgXMGR:
-                            sprintf(buf+b, "%s%c%s", "\\8", c, "\\4");
+                            snprintf(buf+b, buflen-b-1, "%s%c%s", "\\8", c, "\\4");
                             break;
                         default:
                             std::strncat(buf+b, &gmx[g], std::strlen(sym[i]));

--- a/src/gromacs/gmxpreprocess/topdirs.cpp
+++ b/src/gromacs/gmxpreprocess/topdirs.cpp
@@ -309,7 +309,7 @@ directive str2dir (char *dstr)
     /* Hack to be able to read old topologies */
     if (gmx_strncasecmp_min(dstr, "dummies", 7) == 0)
     {
-        sprintf(buf, "virtual_sites%s", dstr+7);
+        snprintf(buf, STRLEN-1, "virtual_sites%s", dstr+7);
         ptr = buf;
     }
     else

--- a/src/gromacs/gmxpreprocess/toputil.cpp
+++ b/src/gromacs/gmxpreprocess/toputil.cpp
@@ -537,9 +537,8 @@ void print_bondeds(FILE *out, int natoms, directive d,
     open_symtab(&stab);
     for (i = 0; (i < natoms); i++)
     {
-        char buf[12];
-        sprintf(buf, "%4d", (i+1));
-        add_atomtype(atype, &stab, a, buf, param, 0, 0);
+        auto buf = gmx::formatString("%4d", (i+1));
+        add_atomtype(atype, &stab, a, buf.c_str(), param, 0, 0);
     }
     print_bt(out, d, atype, ftype, fsubtype, plist, TRUE);
 

--- a/src/gromacs/mdlib/forcerec.cpp
+++ b/src/gromacs/mdlib/forcerec.cpp
@@ -1273,7 +1273,6 @@ static void make_nbf_tables(FILE *fp,
                             const char *tabfn, char *eg1, char *eg2,
                             t_nblists *nbl)
 {
-    char buf[STRLEN];
     int  i, j;
 
     if (tabfn == nullptr)
@@ -1285,14 +1284,15 @@ static void make_nbf_tables(FILE *fp,
         return;
     }
 
-    sprintf(buf, "%s", tabfn);
+    std::string buf(tabfn);
     if (eg1 && eg2)
     {
-        /* Append the two energy group names */
-        sprintf(buf + strlen(tabfn) - strlen(ftp2ext(efXVG)) - 1, "_%s_%s.%s",
-                eg1, eg2, ftp2ext(efXVG));
+        /* Append the two energy group names, before xvg extension */
+        buf = buf.substr(0, buf.size()-4);
+        buf += gmx::formatString("_%s_%s.%s",
+                                 eg1, eg2, ftp2ext(efXVG));
     }
-    nbl->table_elec_vdw = make_tables(fp, ic, buf, rtab, 0);
+    nbl->table_elec_vdw = make_tables(fp, ic, buf.c_str(), rtab, 0);
     /* Copy the contents of the table to separate coulomb and LJ tables too,
      * to improve cache performance.
      */

--- a/src/gromacs/mdlib/gmx_omp_nthreads.cpp
+++ b/src/gromacs/mdlib/gmx_omp_nthreads.cpp
@@ -202,7 +202,7 @@ void gmx_omp_nthreads_read_env(const gmx::MDLogger &mdlog,
         *nthreads_omp = nt_omp;
 
         /* Output the results */
-        sprintf(buffer,
+        snprintf(buffer, STRLEN-1,
                 "\nThe number of OpenMP threads was set by environment variable OMP_NUM_THREADS to %d%s\n\n",
                 nt_omp,
                 bCommandLineSetNthreadsOMP ? " (and the command-line setting agreed with that)" : "");

--- a/src/gromacs/mdlib/membed.cpp
+++ b/src/gromacs/mdlib/membed.cpp
@@ -920,7 +920,7 @@ static void top_update(const char *topfile, rm_t *rm_p, gmx_mtop_t *mtop)
                 for (size_t i = 0; i < mtop->molblock.size(); i++)
                 {
                     nmol = mtop->molblock[i].nmol;
-                    sprintf(buf, "%-15s %5d\n", *(mtop->moltype[mtop->molblock[i].type].name), nmol);
+                    snprintf(buf, STRLEN-1, "%-15s %5d\n", *(mtop->moltype[mtop->molblock[i].type].name), nmol);
                     fprintf(fpout, "%s", buf);
                 }
                 bMolecules = 2;

--- a/src/gromacs/mdlib/sim_util.cpp
+++ b/src/gromacs/mdlib/sim_util.cpp
@@ -183,10 +183,8 @@ void print_start(FILE *fplog, const t_commrec *cr,
                  gmx_walltime_accounting_t walltime_accounting,
                  const char *name)
 {
-    char buf[STRLEN];
-
-    sprintf(buf, "Started %s", name);
-    print_date_and_time(fplog, cr->nodeid, buf,
+    auto buf = gmx::formatString("Started %s", name);
+    print_date_and_time(fplog, cr->nodeid, buf.c_str(),
                         walltime_accounting_get_start_time_stamp(walltime_accounting));
 }
 

--- a/src/gromacs/mdtypes/inputrec.cpp
+++ b/src/gromacs/mdtypes/inputrec.cpp
@@ -726,7 +726,6 @@ void pr_inputrec(FILE *fp, int indent, const char *title, const t_inputrec *ir,
 static void cmp_grpopts(FILE *fp, const t_grpopts *opt1, const t_grpopts *opt2, real ftol, real abstol)
 {
     int  i, j;
-    char buf1[256], buf2[256];
 
     cmp_int(fp, "inputrec->grpopts.ngtc", -1,  opt1->ngtc, opt2->ngtc);
     cmp_int(fp, "inputrec->grpopts.ngacc", -1, opt1->ngacc, opt2->ngacc);
@@ -742,12 +741,12 @@ static void cmp_grpopts(FILE *fp, const t_grpopts *opt1, const t_grpopts *opt2, 
                 opt1->anneal_npoints[i], opt2->anneal_npoints[i]);
         if (opt1->anneal_npoints[i] == opt2->anneal_npoints[i])
         {
-            sprintf(buf1, "inputrec->grpopts.anneal_time[%d]", i);
-            sprintf(buf2, "inputrec->grpopts.anneal_temp[%d]", i);
+            auto buf1 = gmx::formatString("inputrec->grpopts.anneal_time[%d]", i);
+            auto buf2 = gmx::formatString("inputrec->grpopts.anneal_temp[%d]", i);
             for (j = 0; j < opt1->anneal_npoints[i]; j++)
             {
-                cmp_real(fp, buf1, j, opt1->anneal_time[i][j], opt2->anneal_time[i][j], ftol, abstol);
-                cmp_real(fp, buf2, j, opt1->anneal_temp[i][j], opt2->anneal_temp[i][j], ftol, abstol);
+                cmp_real(fp, buf1.c_str(), j, opt1->anneal_time[i][j], opt2->anneal_time[i][j], ftol, abstol);
+                cmp_real(fp, buf2.c_str(), j, opt1->anneal_temp[i][j], opt2->anneal_temp[i][j], ftol, abstol);
             }
         }
     }
@@ -757,8 +756,8 @@ static void cmp_grpopts(FILE *fp, const t_grpopts *opt1, const t_grpopts *opt2, 
         {
             for (j = i; j < opt1->ngener; j++)
             {
-                sprintf(buf1, "inputrec->grpopts.egp_flags[%d]", i);
-                cmp_int(fp, buf1, j,
+                auto buf1 = gmx::formatString("inputrec->grpopts.egp_flags[%d]", i);
+                cmp_int(fp, buf1.c_str(), j,
                         opt1->egp_flags[opt1->ngener*i+j],
                         opt2->egp_flags[opt1->ngener*i+j]);
             }

--- a/src/gromacs/tables/forcetable.cpp
+++ b/src/gromacs/tables/forcetable.cpp
@@ -576,7 +576,6 @@ static void set_forces(FILE *fp, int angle,
 static void read_tables(FILE *fp, const char *filename,
                         int ntab, int angle, t_tabledata td[])
 {
-    char     buf[STRLEN];
     double **yy = nullptr, start, end, dx0, dx1, ssd, vm, vp, f, numf;
     int      k, i, nx, nx0 = 0, ny, nny, ns;
     gmx_bool bAllZero, bZeroV, bZeroF;
@@ -707,20 +706,20 @@ static void read_tables(FILE *fp, const char *filename,
             if (ns > 0)
             {
                 ssd /= ns;
-                sprintf(buf, "For the %d non-zero entries for table %d in %s the forces deviate on average %" PRId64
+                auto buf = gmx::formatString("For the %d non-zero entries for table %d in %s the forces deviate on average %" PRId64
                         "%% from minus the numerical derivative of the potential\n",
                         ns, k, libfn.c_str(), gmx::roundToInt64(100*ssd));
                 if (debug)
                 {
-                    fprintf(debug, "%s", buf);
+                    fprintf(debug, "%s", buf.c_str());
                 }
                 if (ssd > 0.2)
                 {
                     if (fp)
                     {
-                        fprintf(fp, "\nWARNING: %s\n", buf);
+                        fprintf(fp, "\nWARNING: %s\n", buf.c_str());
                     }
-                    fprintf(stderr, "\nWARNING: %s\n", buf);
+                    fprintf(stderr, "\nWARNING: %s\n", buf.c_str());
                 }
             }
         }

--- a/src/gromacs/timing/wallcycle.cpp
+++ b/src/gromacs/timing/wallcycle.cpp
@@ -674,28 +674,23 @@ static void print_cycles(FILE *fplog, double c2t, const char *name,
 static void print_gputimes(FILE *fplog, const char *name,
                            int n, double t, double tot_t)
 {
-    char num[11];
-    char avg_perf[11];
+    std::string num("          ");
+    std::string avg_perf = num;
 
     if (n > 0)
     {
-        snprintf(num, sizeof(num), "%10d", n);
-        snprintf(avg_perf, sizeof(avg_perf), "%10.3f", t/n);
-    }
-    else
-    {
-        sprintf(num, "          ");
-        sprintf(avg_perf, "          ");
+        num = gmx::formatString("%10d", n);
+        avg_perf = gmx::formatString("%10.3f", t/n);
     }
     if (t != tot_t && tot_t > 0)
     {
         fprintf(fplog, " %-29s %10s%12.3f   %s   %5.1f\n",
-                name, num, t/1000, avg_perf, 100 * t/tot_t);
+                name, num.c_str(), t/1000, avg_perf.c_str(), 100 * t/tot_t);
     }
     else
     {
         fprintf(fplog, " %-29s %10s%12.3f   %s   %5.1f\n",
-                name, "", t/1000, avg_perf, 100.0);
+                name, "", t/1000, avg_perf.c_str(), 100.0);
     }
 }
 

--- a/src/gromacs/topology/index.cpp
+++ b/src/gromacs/topology/index.cpp
@@ -404,7 +404,7 @@ static void analyse_prot(const char ** restype, const t_atoms *atoms,
     int        *aid;
     int         nra, npres;
     gmx_bool    match;
-    char        ndx_name[STRLEN], *atnm;
+    char       *atnm;
     int         i;
 
     if (bVerb)
@@ -500,9 +500,9 @@ static void analyse_prot(const char ** restype, const t_atoms *atoms,
                     {
                         t_resinfo *ri;
                         ri = &atoms->resinfo[resind];
-                        sprintf(ndx_name, "%s_%s%d%c",
+                        auto ndx_name = gmx::formatString("%s_%s%d%c",
                                 constructing_data[i].group_name, *ri->name, ri->nr, ri->ic == ' ' ? '\0' : ri->ic);
-                        add_grp(gb, gn, nra, aid, ndx_name);
+                        add_grp(gb, gn, nra, aid, ndx_name.c_str());
                         nra = 0;
                     }
                 }

--- a/src/gromacs/topology/topology.cpp
+++ b/src/gromacs/topology/topology.cpp
@@ -422,24 +422,23 @@ void pr_top(FILE *fp, int indent, const char *title, const t_topology *top,
 static void cmp_ilist(FILE *fp, int ftype, const t_ilist *il1, const t_ilist *il2)
 {
     int  i;
-    char buf[256];
 
     fprintf(fp, "comparing ilist %s\n", interaction_function[ftype].name);
-    sprintf(buf, "%s->nr", interaction_function[ftype].name);
-    cmp_int(fp, buf, -1, il1->nr, il2->nr);
-    sprintf(buf, "%s->iatoms", interaction_function[ftype].name);
+    auto buf = gmx::formatString("%s->nr", interaction_function[ftype].name);
+    cmp_int(fp, buf.c_str(), -1, il1->nr, il2->nr);
+    buf = gmx::formatString("%s->iatoms", interaction_function[ftype].name);
     if (((il1->nr > 0) && (!il1->iatoms)) ||
         ((il2->nr > 0) && (!il2->iatoms)) ||
         ((il1->nr != il2->nr)))
     {
         fprintf(fp, "Comparing radically different topologies - %s is different\n",
-                buf);
+                buf.c_str());
     }
     else
     {
         for (i = 0; (i < il1->nr); i++)
         {
-            cmp_int(fp, buf, i, il1->iatoms[i], il2->iatoms[i]);
+            cmp_int(fp, buf.c_str(), i, il1->iatoms[i], il2->iatoms[i]);
         }
     }
 }
@@ -529,7 +528,6 @@ static void cmp_cmap(FILE *fp, const gmx_cmap_t *cmap1, const gmx_cmap_t *cmap2,
 static void cmp_idef(FILE *fp, const t_idef *id1, const t_idef *id2, real ftol, real abstol)
 {
     int  i;
-    char buf1[64], buf2[64];
 
     fprintf(fp, "comparing idef\n");
     if (id2)
@@ -538,10 +536,10 @@ static void cmp_idef(FILE *fp, const t_idef *id1, const t_idef *id2, real ftol, 
         cmp_int(fp, "idef->atnr",  -1, id1->atnr, id2->atnr);
         for (i = 0; (i < std::min(id1->ntypes, id2->ntypes)); i++)
         {
-            sprintf(buf1, "idef->functype[%d]", i);
-            sprintf(buf2, "idef->iparam[%d]", i);
-            cmp_int(fp, buf1, i, static_cast<int>(id1->functype[i]), static_cast<int>(id2->functype[i]));
-            cmp_iparm(fp, buf2, id1->functype[i],
+            auto buf1 = gmx::formatString("idef->functype[%d]", i);
+            auto buf2 = gmx::formatString("idef->iparam[%d]", i);
+            cmp_int(fp, buf1.c_str(), i, static_cast<int>(id1->functype[i]), static_cast<int>(id2->functype[i]));
+            cmp_iparm(fp, buf2.c_str(), id1->functype[i],
                       id1->iparams[i], id2->iparams[i], ftol, abstol);
         }
         cmp_real(fp, "fudgeQQ", -1, id1->fudgeQQ, id2->fudgeQQ, ftol, abstol);
@@ -562,22 +560,18 @@ static void cmp_idef(FILE *fp, const t_idef *id1, const t_idef *id2, real ftol, 
 
 static void cmp_block(FILE *fp, const t_block *b1, const t_block *b2, const char *s)
 {
-    char buf[32];
-
     fprintf(fp, "comparing block %s\n", s);
-    sprintf(buf, "%s.nr", s);
-    cmp_int(fp, buf, -1, b1->nr, b2->nr);
+    auto buf = gmx::formatString("%s.nr", s);
+    cmp_int(fp, buf.c_str(), -1, b1->nr, b2->nr);
 }
 
 static void cmp_blocka(FILE *fp, const t_blocka *b1, const t_blocka *b2, const char *s)
 {
-    char buf[32];
-
     fprintf(fp, "comparing blocka %s\n", s);
-    sprintf(buf, "%s.nr", s);
-    cmp_int(fp, buf, -1, b1->nr, b2->nr);
-    sprintf(buf, "%s.nra", s);
-    cmp_int(fp, buf, -1, b1->nra, b2->nra);
+    auto buf = gmx::formatString("%s.nr", s);
+    cmp_int(fp, buf.c_str(), -1, b1->nr, b2->nr);
+    buf = gmx::formatString("%s.nra", s);
+    cmp_int(fp, buf.c_str(), -1, b1->nra, b2->nra);
 }
 
 void cmp_top(FILE *fp, const t_topology *t1, const t_topology *t2, real ftol, real abstol)

--- a/src/gromacs/utility/cstringutil.cpp
+++ b/src/gromacs/utility/cstringutil.cpp
@@ -515,6 +515,6 @@ str_to_int64_t(const char *str, char **endptr)
 
 char *gmx_step_str(int64_t i, char *buf)
 {
-    sprintf(buf, "%" PRId64, i);
+    snprintf(buf, strlen(buf)-1, "%" PRId64, i);
     return buf;
 }

--- a/src/gromacs/utility/fatalerror.cpp
+++ b/src/gromacs/utility/fatalerror.cpp
@@ -250,24 +250,17 @@ void _gmx_error(const char *key, const std::string &msg, const char *file, int l
 void _range_check(int n, int n_min, int n_max, const char *warn_str,
                   const char *var, const char *file, int line)
 {
-    char buf[1024];
-
     if ((n < n_min) || (n >= n_max))
     {
+        std::string buf;
         if (warn_str != nullptr)
         {
-            strcpy(buf, warn_str);
-            strcat(buf, "\n");
+            buf = gmx::formatString("%s\n", warn_str);
         }
-        else
-        {
-            buf[0] = '\0';
-        }
+        buf += gmx::formatString("Variable %s has value %d. It should have been "
+                                 "within [ %d .. %d ]\n", var, n, n_min, n_max);
 
-        sprintf(buf+strlen(buf), "Variable %s has value %d. It should have been "
-                "within [ %d .. %d ]\n", var, n, n_min, n_max);
-
-        _gmx_error("range", buf, file, line);
+        _gmx_error("range", buf.c_str(), file, line);
     }
 }
 
@@ -277,7 +270,7 @@ void gmx_warning(gmx_fmtstr const char *fmt, ...)
     char    msg[STRLEN];
 
     va_start(ap, fmt);
-    vsprintf(msg, fmt, ap);
+    vsnprintf(msg, STRLEN-1, fmt, ap);
     va_end(ap);
 
     fprintf(stderr, "\nWARNING: %s\n\n", msg);


### PR DESCRIPTION
In most cases it was replaced by gmx::formatString which generates a std::string. In some complicated cases snprintf was used.

Part of #177