### PR TITLE
Fixed bug in printing topology and added warning to gentop.

### DIFF
--- a/src/act/alexandria/actmol.cpp
+++ b/src/act/alexandria/actmol.cpp
@@ -954,14 +954,15 @@ void ACTMol::PrintTopology(const char                  *fn,
             auto gp = qmProperty(mpo, T, JobType::OPT);
             if (gp)
             {
-                //auto vec = gp->getVector();
-                //qelec->setMultipole(mpo, vec);
-                auto mymu = qelec.getMultipole(mpo);
-                commercials.push_back(gmx::formatString("%s %s (%s)\n",
-                                                        mylot.c_str(), mpo_name(mpo), gp->getUnit()));
-                for(auto &fmp : formatMultipole(mpo, mymu))
+                if (qelec.hasMultipole(mpo))
                 {
-                    commercials.push_back(fmp);
+                    auto mymu = qelec.getMultipole(mpo);
+                    commercials.push_back(gmx::formatString("%s %s (%s)\n",
+                                                            mylot.c_str(), mpo_name(mpo), gp->getUnit()));
+                    for(auto &fmp : formatMultipole(mpo, mymu))
+                    {
+                        commercials.push_back(fmp);
+                    }
                 }
                 if (qcalc->hasMultipole(mpo))
                 {

--- a/src/act/alexandria/gentop.cpp
+++ b/src/act/alexandria/gentop.cpp
@@ -278,6 +278,10 @@ int gentop(int argc, char *argv[])
             fprintf(stderr, "Could not read molecule(s) from  input file %s.\n", molFile);
             return 1;
         }
+        if (nullptr != opt2fn_null("-pdbdiff",  NFILE, fnm))
+        {
+            fprintf(stderr, "WARNING: Cannot generate a pdbdiff file from user defined coordinates. Use the -db flag instead.\n");
+        }
     }
     else
     {


### PR DESCRIPTION
Added a warning about not being able to generate a pdbdiff file from user coordinates.

Fixed bug for non-initialized electronic multipoles when printing a topology file from gentop.

Fixes #213