### PR TITLE
Fixed issue with different charges for the same compound.

### DIFF
--- a/src/act/alexandria/actmol_low.cpp
+++ b/src/act/alexandria/actmol_low.cpp
@@ -72,6 +72,7 @@ std::map<immStatus, const char *> immMessages = {
     { immStatus::BondOrder,                "Determining bond order" },
     { immStatus::RespInit,                 "RESP Initialization" },
     { immStatus::ChargeGeneration,         "Charge generation" },
+    { immStatus::MissingChargeGenerationParameters, "Parameters for charge generation missing" },
     { immStatus::ShellMinimization,        "Shell minimization" },
     { immStatus::Topology,                 "No input to generate a topology" },
     { immStatus::QMInconsistency,          "QM Inconsistency (ESP dipole does not match Electronic)" },

--- a/src/act/alexandria/actmol_low.h
+++ b/src/act/alexandria/actmol_low.h
@@ -98,6 +98,8 @@ enum class immStatus {
     NoMolpropCharges,
     //! Problem generating charges
     ChargeGeneration,
+    //! Missing charge generation parameters
+    MissingChargeGenerationParameters,
     //! Shell minimization did not converge
     ShellMinimization,
     //! QM Inconsistency (ESP dipole does not match Electronic)

--- a/src/act/alexandria/fragmenthandler.cpp
+++ b/src/act/alexandria/fragmenthandler.cpp
@@ -215,6 +215,24 @@ eQgen FragmentHandler::generateCharges(FILE                         *fp,
     return eqgen;
 }
 
+bool FragmentHandler::fetchCharges(std::vector<ActAtom> *atoms)
+{
+    if (atoms->size() != natoms_)
+    {
+        return false;
+    }
+    size_t k = 0;
+    for(size_t i = 0; i < topologies_.size(); i++)
+    {
+        auto ats = topologies_[i]->atoms();
+        for(size_t j = 0; j < ats.size(); j++)
+        {
+            (*atoms)[k++].setCharge(ats[j].charge());
+        }
+    }
+    return true;
+}
+
 bool FragmentHandler::setCharges(const std::map<std::string, std::vector<double> >&qmap)
 {
     bool success = true;
@@ -241,6 +259,7 @@ bool FragmentHandler::setCharges(const std::map<std::string, std::vector<double>
             success = false;
         }
     }
+    fixedQ_ = success;
     return success;
 }
 

--- a/src/act/alexandria/fragmenthandler.h
+++ b/src/act/alexandria/fragmenthandler.h
@@ -55,6 +55,8 @@ namespace alexandria
         std::vector<size_t>                atomStart_;
         //! Pointer to copy of the fragments
         std::vector<double>                qtotal_;
+        //! Whether charges are fixed or not. They are when set from a charge map.
+        bool                               fixedQ_ = false;
         //! Total number of atoms
         size_t                             natoms_ = 0;
     public:
@@ -105,13 +107,18 @@ namespace alexandria
          * \param[in] atoms The atoms from the complete topology for all fragments
          */
         void setCharges(const std::vector<ActAtom> &atoms);
-        
+        /*! \brief Copy charges from fragments back to atoms
+         * \param[inout] atoms The atoms to copy to.
+         * \return whether atoms->size() equals the sum of the number of atoms in the fragments.
+         */
+        bool fetchCharges(std::vector<ActAtom> *atoms);
         /*! \brief Copy charges from a charge map
          * \param[in] qmap The charge map
          * \return true if charges for all fragments were found
          */
         bool setCharges(const std::map<std::string, std::vector<double> >&qmap);
-        
+        //! \return whether charges are fixed or not
+        bool fixedCharges() const { return fixedQ_; }
         /*! \brief Set the charge generation algorithm to use
          * \param[in] alg The algorithm to use. Only Read or EEM/SQE are supported.
          */

--- a/src/act/alexandria/gentop.cpp
+++ b/src/act/alexandria/gentop.cpp
@@ -358,7 +358,12 @@ int gentop(int argc, char *argv[])
             actmol.getExpProps(&pd, iqm, 0.0, 0.0, maxpot);
             auto fragments  = actmol.fragmentHandler();
             auto topologies = fragments->topologies();
-            if (!fragments->setCharges(qmap))
+            if (fragments->setCharges(qmap))
+            {
+                // Copy charges to the high-level topology as well
+                fragments->fetchCharges(actmol.atoms());
+            }
+            else
             {
                 auto qtype = qType::Calc;
                 std::vector<double> myq;

--- a/src/act/alexandria/molgen.cpp
+++ b/src/act/alexandria/molgen.cpp
@@ -755,7 +755,12 @@ size_t MolGen::Read(FILE                                *fp,
                 if (immStatus::OK == imm)
                 {
                     auto fragments = actmol.fragmentHandler();
-                    if (!fragments->setCharges(qmap))
+                    if (fragments->setCharges(qmap))
+                    {
+                        // Copy charges to the high-level topology as well
+                        fragments->fetchCharges(actmol.atoms());
+                    }
+                    else
                     {
                         if (fp)
                         {
@@ -941,7 +946,12 @@ size_t MolGen::Read(FILE                                *fp,
             if (immStatus::OK == imm)
             {
                 auto fragments = actmol.fragmentHandler();
-                if (!fragments->setCharges(qmap))
+                if (fragments->setCharges(qmap))
+                {
+                    // Copy charges to the high-level topology as well
+                    fragments->fetchCharges(actmol.atoms());
+                }
+                else
                 {
                     std::vector<gmx::RVec> forces(actmol.atomsConst().size());
                     std::vector<double> dummy;

--- a/src/act/alexandria/train_utility.cpp
+++ b/src/act/alexandria/train_utility.cpp
@@ -1309,8 +1309,6 @@ void TrainForceFieldPrinter::print(FILE                            *fp,
     auto forceComp = new ForceComputer();
     AtomizationEnergy atomenergy;
     std::map<std::string, double> molEpot;
-    auto alg   = pd->chargeGenerationAlgorithm();
-    auto qtype = qType::Calc;
     std::map<std::string, std::vector<ACTEnergy > > allEpot; 
     std::map<std::string, std::vector<ACTEnergy > > allEinter; 
     for (auto mol = actmol->begin(); mol < actmol->end(); ++mol)
@@ -1326,12 +1324,9 @@ void TrainForceFieldPrinter::print(FILE                            *fp,
                     mol->symmetryNumber(),
                     iMolSelectName(ims));
 
-            // Recalculate the atomic charges using the optimized parameters.
-            std::vector<double>    dummy;
             gmx::RVec vzero = { 0, 0, 0 };
             std::vector<gmx::RVec> forces(mol->atomsConst().size(), vzero);
             std::vector<gmx::RVec> coords = mol->xOriginal();
-            mol->GenerateCharges(pd, forceComp, alg, qtype, dummy, &coords, &forces);
             // Now compute all the ESP RMSDs and multipoles and print it.
             fprintf(fp, "Electrostatic properties.\n");
             for (auto &i : qTypes())

--- a/src/act/python/act.py
+++ b/src/act/python/act.py
@@ -140,10 +140,12 @@ class ACT:
         if not os.path.exists(ForceFieldFileIn):
             sys.exit("No force field file %s" % ForceFieldFileIn)
 
-        cmd = ( "alexandria train_ff -ff %s -o %s -mp %s -charges %s -sel %s -g %s" % 
+        cmd = ( "alexandria train_ff -ff %s -o %s -mp %s -sel %s -g %s" %
                 ( ForceFieldFileIn, ForceFieldFileOut,
-                  self.molpropfile, self.chargesfile,
+                  self.molpropfile,
                   self.selectionfile, LogFile ) )
+        if len(self.chargesfile) > 0:
+            cmd += " -charges " + self.chargesfile
         for opt in options:
             cmd += ( " %s %s " % ( opt, options[opt] ))
         ener_params = [ "sigma", "epsilon", "gamma", "kt", "klin", "kimp", "De", "D0", "beta", "kphi", "phi0", "c1", "c2", "c3", "bondenergy" ]


### PR DESCRIPTION
In training of intermolecular as well as intramolecular energies, the charges on identical compounds are read from a user supplied molprop file specified with the -charges option. Once this file is read and processed in the fragmenthandles, charge generation will not be redone.

TODO: Implement charge map reading in other programs than gentop and train_ff

Part of #166.