### PR TITLE
Added some glue to prevent users from running meaningless training.

### DIFF
--- a/src/act/python/act.py
+++ b/src/act/python/act.py
@@ -145,7 +145,10 @@ class ACT:
                   self.molpropfile,
                   self.selectionfile, LogFile ) )
         if len(self.chargesfile) > 0:
-            cmd += " -charges " + self.chargesfile
+            if Target.ACM == target:
+                print("Ignoring charges file when optimizing charge properties")
+            else:
+                cmd += " -charges " + self.chargesfile
         for opt in options:
             cmd += ( " %s %s " % ( opt, options[opt] ))
         ener_params = [ "sigma", "epsilon", "gamma", "kt", "klin", "kimp", "De", "D0", "beta", "kphi", "phi0", "c1", "c2", "c3", "bondenergy" ]


### PR DESCRIPTION
When the -charges option is passed to train_ff, the charges will be computed just once in the beginning of the training. This does not make sense when optimizing charge parameters.

Part of #166