### PR TITLE
Introduced destructor for ForceComputer

### DIFF
--- a/src/act/forces/forcecomputer.cpp
+++ b/src/act/forces/forcecomputer.cpp
@@ -65,6 +65,14 @@ ForceComputer::ForceComputer(double   msForce,
     vsiteHandler_ = new VsiteHandler(box_, dt);
 }
 
+ForceComputer::~ForceComputer()
+{
+    if (vsiteHandler_)
+    {
+        delete vsiteHandler_;
+    }
+}
+
 double ForceComputer::compute(const ForceField                  *pd,
                               const Topology                    *top,
                               std::vector<gmx::RVec>            *coordinates,

--- a/src/act/forces/forcecomputer.h
+++ b/src/act/forces/forcecomputer.h
@@ -79,7 +79,10 @@ private:
      */
     ForceComputer(double   msForce = 1e-6,
                   int      maxiter = 25);
-    
+
+    //! \brief Destructor
+    ~ForceComputer();
+
     /*! Do complete energy/force computation.
      * If shells are present their positions will be minimized.
      * \param[in]  pd          Pointer to force field structure


### PR DESCRIPTION
Since this class allocates memory on the heap for the vsitehandler the memory needs to be released as well.

Fixes #264