### PR TITLE
Fixed a number of issues to do with virtual sites.

### DIFF
--- a/src/act/alexandria/allbondeds.cpp
+++ b/src/act/alexandria/allbondeds.cpp
@@ -222,6 +222,7 @@ void AllBondeds::addBonded(FILE                           *fplog,
     case InteractionType::VDW:
     case InteractionType::VSITE2:
     case InteractionType::VSITE3:
+    case InteractionType::VSITE3FD:
     case InteractionType::VSITE3OUT:
         // Nothing to be done for non-bonded interactions.
         return;

--- a/src/act/alexandria/devcomputer.cpp
+++ b/src/act/alexandria/devcomputer.cpp
@@ -270,7 +270,7 @@ void EspDevComputer::calcDeviation(gmx_unused const ForceComputer    *forceCompu
     auto topology = actmol->topology();
     std::vector<gmx::RVec> forces(topology->atoms().size());
     std::map<InteractionType, double> energies;
-    bool doForce = forcefield->polarizable() || topology->hasEntry(InteractionType::VSITE2);
+    bool doForce = forcefield->polarizable() || topology->hasVsites();
     // Loop over zero or more ESP data sets.
     for(auto qc = qProps->begin(); qc < qProps->end(); qc++)
     {

--- a/src/act/alexandria/molgen.cpp
+++ b/src/act/alexandria/molgen.cpp
@@ -423,10 +423,15 @@ void MolGen::checkDataSufficiency(FILE        *fp,
                             {
                                 if (fp)
                                 {
-                                    fprintf(fp, "Cannot find parameter %s CanSwap %s swapped %s in parameter list %s CanSwap %s\n",
+                                    std::string swapped;
+                                    if (topentry->id().haveSwapped())
+                                    {
+                                        swapped = topentry->id().swapped();
+                                    }
+                                    fprintf(fp, "Cannot find parameter '%s' CanSwap %s swapped '%s' in parameter list %s CanSwap %s\n",
                                             topentry->id().id().c_str(),
                                             canSwapToString(topentry->id().canSwap()).c_str(),
-                                            topentry->id().swapped().c_str(),
+                                            swapped.c_str(),
                                             interactionTypeToString(atype).c_str(),
                                             canSwapToString(angles->canSwap()).c_str());
                                 }

--- a/src/act/alexandria/topology.h
+++ b/src/act/alexandria/topology.h
@@ -385,6 +385,9 @@ private:
      */
     bool hasEntry(InteractionType itype) const { return entries_.find(itype) != entries_.end(); }
 
+    //! \return whether there are any virtual sites
+    bool hasVsites() const;
+
     /*! \brief Return the desired entry or throw
      * \param[in] itype The desired interaction type
      * \return a vector of pointers

--- a/src/act/basics/identifier.h
+++ b/src/act/basics/identifier.h
@@ -111,6 +111,9 @@ class Identifier
      */
     const std::string &id() const;
 
+    //! \return whether a swapped id exists
+    bool haveSwapped() const { return ids_.size() > 1; }
+
     /*! \brief Return swapped identifier string
      * \throws if there are no ids
      */

--- a/src/act/forcefield/gen_ff.cpp
+++ b/src/act/forcefield/gen_ff.cpp
@@ -153,7 +153,7 @@ static void add_vsites(const char *vsfile,
     int                      lineno = 1;
     ForceFieldParameterList  vsite2("vsite2", CanSwap::Vsite2);
     ForceFieldParameterList  vsite3("vsite3", CanSwap::Vsite3);
-    ForceFieldParameterList  vsite3fd("vsite3", CanSwap::No);
+    ForceFieldParameterList  vsite3fd("vsite3fd", CanSwap::No);
     ForceFieldParameterList  vsite3out("vsite3out", CanSwap::No);
     while (tr.readLine(&tmp))
     {


### PR DESCRIPTION
- Rewrote Vsite3FD to match ordering of atoms.
- Added method in Topology class to check whether there are any virtual sites, and call it from devcomputer.cpp.
- Clarified some warnings.
- Reorganized Topology::makeVsites3 to function with all types of
- Vsite3 and to put the vsites in the correct list.
- Added support to gen_ff and geometry_ff for VSITE3FD
- Fixed operator < in Identifier class.

Sorry for large patch, should have split it into multiple.