### PR TITLE
Added test to check that mutability is set to Fixed for min==max

### DIFF
--- a/src/act/forcefield/forcefield_parameter.h
+++ b/src/act/forcefield/forcefield_parameter.h
@@ -66,6 +66,8 @@ class ForceFieldParameter
     
     /*! \brief Constructor initiating all parameters.
      *
+     * If min and max are equal, mutability will be set to Fixed
+     * automatically.
      * TODO: Check unit
      * \param[in] unit        Physical unit of parameter, e.g. nm or fs
      * \param[in] value       Actual value of the parameter

--- a/src/act/forcefield/tests/forcefield_parameter_test.cpp
+++ b/src/act/forcefield/tests/forcefield_parameter_test.cpp
@@ -168,6 +168,11 @@ TEST(ForceFieldParameterSimpleTest, NtrainStrict) {
     EXPECT_THROW(fp.setNtrain(30), gmx::InternalError);
 }
 
+TEST(ForceFieldParameterSimpleTest, MinEqualsMaxSetMutabilityFixed) {
+    ForceFieldParameter    fp("kJ/mol", 15.0, 0.25, 45, 15.0, 15.0, Mutability::Bounded, true, true);
+    EXPECT_TRUE(fp.mutability() == Mutability::Fixed);
+}
+
 TEST(ForceFieldParameterSimpleTest, NameToMutability) {
     Mutability m;
     EXPECT_TRUE(nameToMutability("Free", &m));


### PR DESCRIPTION
As a matter of fact the code to change mutability to fixed if minimum and maximum were the same was already in place.

Also updated the comment in the constructor header.

Fixes #317