### PR TITLE
Rename "gentop" to "alexandria_chemistry" in FF files.

### DIFF
--- a/src/act/forcefield/combruleutil.cpp
+++ b/src/act/forcefield/combruleutil.cpp
@@ -92,18 +92,17 @@ void CombRuleUtil::addPargs(std::vector<t_pargs> *pa)
 {
     for(const auto &cr : mycr)
     {
-        desc_.resize(desc_.size() + cr.second.size());
         cr_flag_.resize(cr_flag_.size() + cr.second.size());
     }
     for(const auto &cr : mycr)
     {
         for (const auto &mm : cr.second)
         {
-            desc_[mm.index] = gmx::formatString("Combination rule to use for %s parameter %s",
-                                                interactionTypeToString(cr.first).c_str(),
-                                                mm.var);
-            t_pargs mp = { mm.flag, FALSE, etSTR, {&cr_flag_[mm.index]}, desc_[mm.index].c_str() };
-            pa->push_back(mp);
+            auto desc = gmx::formatString("Combination rule to use for %s parameter %s",
+                                          interactionTypeToString(cr.first).c_str(),
+                                          mm.var);
+            pa_.push_back({ mm.flag, FALSE, etSTR, {&cr_flag_[mm.index]}, desc.c_str() });
+            pa->push_back(pa_.back());
         }
     }
 }
@@ -118,6 +117,11 @@ int CombRuleUtil::extract(ForceFieldParameterList *vdw,
     {
         for(const auto &mm : mcr.second)
         {
+            // If this has not been touched on the command line, do nothing.
+            if (!pa_[mm.index].bSet)
+            {
+                continue;
+            }
             auto value = cr_flag_[mm.index];
             if (!value || strlen(value) == 0)
             {

--- a/src/act/forcefield/combruleutil.h
+++ b/src/act/forcefield/combruleutil.h
@@ -46,9 +46,8 @@ namespace alexandria
     private:
         // Storage for the command line options
         std::vector<const char *> cr_flag_;
-        // Description of options
-        std::vector<std::string>  desc_;
-
+        // Command line options
+        std::vector<t_pargs>      pa_;
     public:
         /*! \brief Utility to make command line information about combrules
          * \param[inout] crinfo Array of strings to be edited

--- a/src/act/forcefield/forcefield_xml.cpp
+++ b/src/act/forcefield/forcefield_xml.cpp
@@ -84,6 +84,7 @@ const char *xmltypes[] = {
 //! The different entries to excpect in force field file
 enum class xmlEntry {
     GENTOP,
+    ACT,
     TIMESTAMP,
     CHECKSUM,
     REFERENCE,
@@ -144,6 +145,7 @@ enum class xmlEntry {
 std::map<const std::string, xmlEntry> xml_pd =
 {
     { "gentop",                    xmlEntry::GENTOP           },
+    { "alexandria_chemistry",      xmlEntry::ACT              },
     { "timestamp",                 xmlEntry::TIMESTAMP        },
     { "checksum",                  xmlEntry::CHECKSUM         },
     { "reference",                 xmlEntry::REFERENCE        },
@@ -772,8 +774,8 @@ void writeForceField(const std::string &fileName,
     xmlChar    *libdtdname, *dtdname, *gmx;
 
     rmap_pd.clear();
-    gmx        = (xmlChar *) "gentop";
-    dtdname    = (xmlChar *) "gentop.dtd";
+    gmx        = (xmlChar *) "alexandria_chemistry";
+    dtdname    = (xmlChar *) "alexandria_chemistry.dtd";
     libdtdname = dtdname;
 
     if ((doc = xmlNewDoc((xmlChar *)"1.0")) == nullptr)

--- a/src/act/forcefield/tests/ACM-g.xml
+++ b/src/act/forcefield/tests/ACM-g.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE gentop.dtd PUBLIC "gentop.dtd" "gentop.dtd">
-<gentop>
-  <version checksum="3af822716c329c97c571cfe9d301b30f" timestamp="2024-05-07 22:48:22"/>
+<!DOCTYPE alexandria_chemistry.dtd PUBLIC "alexandria_chemistry.dtd" "alexandria_chemistry.dtd">
+<alexandria_chemistry>
+  <version checksum="0b190d6d59475f2ef2bdc7bd519390a9" timestamp="2024-06-17 11:39:04"/>
   <particletypes>
     <particletype identifier="Be2+" type="Atom" description="beryllium ion">
       <option key="atomnumber" value="4"/>
@@ -14860,4 +14860,4 @@
     <sym_charge central="C" attached="I" numattach="3"/>
     <sym_charge central="Si" attached="H" numattach="3"/>
   </symmetric_charges>
-</gentop>
+</alexandria_chemistry>

--- a/src/act/forcefield/tests/ACM-pg.xml
+++ b/src/act/forcefield/tests/ACM-pg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE gentop.dtd PUBLIC "gentop.dtd" "gentop.dtd">
-<gentop>
-  <version checksum="0462e77d43f1ba8f73c5f6136c5bf0aa" timestamp="2024-05-07 22:49:10"/>
+<!DOCTYPE alexandria_chemistry.dtd PUBLIC "alexandria_chemistry.dtd" "alexandria_chemistry.dtd">
+<alexandria_chemistry>
+  <version checksum="3e71514b1280250ebf15814ec611cc8c" timestamp="2024-06-17 11:36:31"/>
   <particletypes>
     <particletype identifier="Be2+" type="Atom" description="beryllium ion">
       <option key="atomnumber" value="4"/>
@@ -15032,4 +15032,4 @@
     <sym_charge central="C" attached="I" numattach="3"/>
     <sym_charge central="Si" attached="H" numattach="3"/>
   </symmetric_charges>
-</gentop>
+</alexandria_chemistry>

--- a/src/act/forcefield/tests/refdata/ActCheckSumTest_ACM_g.xml
+++ b/src/act/forcefield/tests/refdata/ActCheckSumTest_ACM_g.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="referencedata.xsl"?>
 <ReferenceData>
-  <String Name="ForceField checksum">3af822716c329c97c571cfe9d301b30f</String>
+  <String Name="ForceField checksum">0b190d6d59475f2ef2bdc7bd519390a9</String>
 </ReferenceData>

--- a/src/act/forcefield/tests/refdata/ActCheckSumTest_ACM_pg.xml
+++ b/src/act/forcefield/tests/refdata/ActCheckSumTest_ACM_pg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="referencedata.xsl"?>
 <ReferenceData>
-  <String Name="ForceField checksum">0462e77d43f1ba8f73c5f6136c5bf0aa</String>
+  <String Name="ForceField checksum">3e71514b1280250ebf15814ec611cc8c</String>
 </ReferenceData>


### PR DESCRIPTION
Fixes #425