### PR TITLE
gen_ff ignored combination rules on the command line

### DIFF
--- a/src/act/forcefield/combruleutil.cpp
+++ b/src/act/forcefield/combruleutil.cpp
@@ -101,14 +101,17 @@ void CombRuleUtil::addPargs(std::vector<t_pargs> *pa)
             auto desc = gmx::formatString("Combination rule to use for %s parameter %s",
                                           interactionTypeToString(cr.first).c_str(),
                                           mm.var);
-            pa_.push_back({ mm.flag, FALSE, etSTR, {&cr_flag_[mm.index]}, desc.c_str() });
-            pa->push_back(pa_.back());
+            //pa_.push_back({ mm.flag, FALSE, etSTR, {&cr_flag_[mm.index]}, desc.c_str() });
+            //pa->push_back(pa_.back());
+            pa->push_back({ mm.flag, FALSE, etSTR, {&cr_flag_[mm.index]},
+                    desc.c_str() });
         }
     }
 }
 
-int CombRuleUtil::extract(ForceFieldParameterList *vdw,
-                          ForceFieldParameterList *qt)
+int CombRuleUtil::extract(const std::vector<t_pargs> &pa,
+                          ForceFieldParameterList    *vdw,
+                          ForceFieldParameterList    *qt)
 {
     // This will crash if there is no geometric combrule in the map...
     const char *defval = combRuleName.find(CombRule::Geometric)->second.c_str();
@@ -118,7 +121,7 @@ int CombRuleUtil::extract(ForceFieldParameterList *vdw,
         for(const auto &mm : mcr.second)
         {
             // If this has not been touched on the command line, do nothing.
-            if (!pa_[mm.index].bSet)
+            if (!opt2parg_bSet(mm.flag, pa.size(), pa.data()))
             {
                 continue;
             }

--- a/src/act/forcefield/combruleutil.h
+++ b/src/act/forcefield/combruleutil.h
@@ -46,8 +46,6 @@ namespace alexandria
     private:
         // Storage for the command line options
         std::vector<const char *> cr_flag_;
-        // Command line options
-        std::vector<t_pargs>      pa_;
     public:
         /*! \brief Utility to make command line information about combrules
          * \param[inout] crinfo Array of strings to be edited
@@ -60,12 +58,14 @@ namespace alexandria
         void addPargs(std::vector<t_pargs> *pa);
 
         /*! \brief Utility to convert strings to combination rules in the FF
-         * \param[inout] vdw     The parameter list for Van der Waals (may be nullptr)
-         * \param[inout] qt      The parameter list for Charge Transfer (may be nullptr)
+         * \param[inout] pa  Command line arguments after processing  
+         * \param[inout] vdw The parameter list for Van der Waals (may be nullptr)
+         * \param[inout] qt  The parameter list for Charge Transfer (may be nullptr)
          * \return the number of rules that were changed.
          */
-        int extract(ForceFieldParameterList *vdw,
-                    ForceFieldParameterList *qt);
+        int extract(const std::vector<t_pargs> &pa,
+                    ForceFieldParameterList    *vdw,
+                    ForceFieldParameterList    *qt);
 
         /*! \brief Utility to convert old-style combination rule to new
          * \param[inout] vdw     The parameter list

--- a/src/act/forcefield/edit_ff.cpp
+++ b/src/act/forcefield/edit_ff.cpp
@@ -898,7 +898,8 @@ int edit_ff(int argc, char*argv[])
             fst.second = pd.findForces(fst.first);
         }
     }
-    int nRuleChanged = crule.extract(its[InteractionType::VDW],
+    int nRuleChanged = crule.extract(pa,
+                                     its[InteractionType::VDW],
                                      its[InteractionType::CHARGETRANSFER]);
     if (nRuleChanged > 0)
     {

--- a/src/act/forcefield/gen_ff.cpp
+++ b/src/act/forcefield/gen_ff.cpp
@@ -378,7 +378,7 @@ int gen_ff(int argc, char*argv[])
     ForceFieldParameterList vdw(vdwfn[0], CanSwap::Yes);
     ForceFieldParameterList qt(potentialToString(Potential::EXPONENTIAL), CanSwap::Yes);
     // Combination rules
-    crule.extract(&vdw, &qt);
+    crule.extract(pa, &vdw, &qt);
     vdw.addOption("nexcl", gmx_itoa(nexclvdw));
     ForceFieldParameterList eem("", CanSwap::No);
     // Check for Point charges


### PR DESCRIPTION
This lead to incorrect force field files lacking combination rules.

Fixes #439