### PR TITLE
Fixed two segvs and a communication error

### DIFF
--- a/src/act/forcefield/combruleutil.cpp
+++ b/src/act/forcefield/combruleutil.cpp
@@ -184,13 +184,16 @@ int CombRuleUtil::extract(const std::vector<t_pargs> &pa,
 int CombRuleUtil::convert(ForceFieldParameterList *vdw)
 {
     int changed = 0;
-    std::string crule("combination_rule");
-    if (vdw->optionExists(crule))
+    if (vdw)
     {
-        for(auto &crule : getCombinationRule(*vdw))
+        std::string crule("combination_rule");
+        if (vdw->optionExists(crule))
         {
-            vdw->addCombinationRule(crule.first, combinationRuleName(crule.second));
-            changed += 1;
+            for(auto &crule : getCombinationRule(*vdw))
+            {
+                vdw->addCombinationRule(crule.first, combinationRuleName(crule.second));
+                changed += 1;
+            }
         }
     }
         

--- a/src/act/forcefield/edit_ff.cpp
+++ b/src/act/forcefield/edit_ff.cpp
@@ -911,8 +911,10 @@ int edit_ff(int argc, char*argv[])
         nRuleChanged = crule.convert(its[InteractionType::VDW]);
         printf("Converted old style comb rule to %d new style combination rules.\n", nRuleChanged);
     }
-    its[InteractionType::VDW]->removeOption("combination_rule");
-
+    if (its[InteractionType::VDW])
+    {
+        its[InteractionType::VDW]->removeOption("combination_rule");
+    }
     if (opt2bSet("-o", NFILE, fnm))
     {
         if (cr.isParallel())
@@ -951,7 +953,7 @@ int edit_ff(int argc, char*argv[])
                     cs = pd.Receive(&cr, 0);
                     cr.recv(0, &outfile);
                 }
-                if (CommunicationStatus::OK == cs && cr.rank() == 2)
+                if (CommunicationStatus::OK == cs && cr.rank() == 1)
                 {
                     alexandria::writeForceField(outfile, &pd, 0);
                 }

--- a/src/act/forcefield/forcefield_parameterlist.cpp
+++ b/src/act/forcefield/forcefield_parameterlist.cpp
@@ -429,8 +429,6 @@ CommunicationStatus ForceFieldParameterList::Receive(const CommunicationRecord *
         cr->recv(src, &noptions);
         options_.clear();
         size_t ncrule;
-        cr->recv(src, &ncrule);
-        combrules_.clear();
         for(size_t i = 0; i < noptions; i++)
         {
             std::string key, value;
@@ -438,6 +436,8 @@ CommunicationStatus ForceFieldParameterList::Receive(const CommunicationRecord *
             cr->recv(src, &value);
             options_.insert({key, value});
         }
+        cr->recv(src, &ncrule);
+        combrules_.clear();
         for(size_t i = 0; i < ncrule; i++)
         {
             std::string key, value;


### PR DESCRIPTION
The communication error was in send/receive of forcefieldparameterlists and this code has been replaced by broadcasting.

The segvs occured when edit_ff assumed that there always are certain interaction types, but sometimes they are not there.

Fixes #453