### PR TITLE
Proposed change to fix #480

### DIFF
--- a/src/act/python/act_openmm.py
+++ b/src/act/python/act_openmm.py
@@ -1611,14 +1611,19 @@ class ActOpenMMSim:
 
     def run(self):
         self.setup()
+        # load previous state; no equilibration
         if self.chkReporter and self.chkfile and os.path.isfile(self.chkfile):
             with open(self.chkfile, 'rb') as chk:
                 self.simulation.context.loadCheckpoint(chk.read())
             self.print_energy("After loading checkpoint")
+        # start fresh; start by equilibration
         else:
             self.minimize(maxIter=100)
             self.equilibrate()
             self.print_energy("After equilibration")
+        # reset time (former outputs will be overwritten anyway)
+        self.simulation.context.setTime(0.0)
+        # finally, run production
         self.production()
         self.print_energy("After production")
 


### PR DESCRIPTION
This will reset the time for a simulation and essentially fix #480.

Whether equilibrating when running from scratch or loading a checkpoint, it would make sense to me to reset the simulation time. Even when continuing a run of e.g. 10 ns from a checkpoint and then running another 10 ns, the output energies.csv file would be deleted anyway (the initial 0-10 ns data would be overwritten by 10-20 ns), so resetting time does not make a major difference. Keeping the original 10 ns is a problem in the OpenMM DataReporter class that would be too much of a hassle to fix and is an issue for another time.