### PR TITLE
Make missing parameters an error but only exit when needed.

### DIFF
--- a/src/act/alexandria/actmol.cpp
+++ b/src/act/alexandria/actmol.cpp
@@ -176,7 +176,7 @@ void ACTMol::checkAtoms(MsgHandler       *msghandler,
         auto atype = myatoms[i].ffType();
         if (!pd->hasParticleType(atype))
         {
-            msghandler->msg(ACTStatus::Warning, ACTMessage::MissingFFParameter,
+            msghandler->msg(ACTStatus::Error, ACTMessage::MissingFFParameter,
                             gmx::formatString("Could not find a force field entry for atomtype %s atom %zu in compound '%s'", atype.c_str(), i+1, getMolname().c_str()).c_str());
         }
         else

--- a/src/act/alexandria/fetch_charges.cpp
+++ b/src/act/alexandria/fetch_charges.cpp
@@ -63,10 +63,11 @@ chargeMap fetchChargeMap(MsgHandler                  *msghandler,
         {
             continue;
         }
+        bool addThisMol = false;
         // Check lookup table of compounds
         if (!lookup.empty())
         {
-            bool addThisMol = lookup.find(mp->getIupac()) != lookup.end();
+            addThisMol = lookup.find(mp->getIupac()) != lookup.end();
             if (!addThisMol)
             {
                 // Look for synonyms
@@ -78,16 +79,11 @@ chargeMap fetchChargeMap(MsgHandler                  *msghandler,
                         addThisMol = addThisMol || (lookup.find(syn) != lookup.end());
                     }
                 }
-                else
-                {
-                    amol = amols.findInChi(mp->getInchi());
-                    addThisMol = amol != nullptr;
-                }
             }
-            if (!addThisMol)
-            {
-                continue;
-            }
+        }
+        if (!addThisMol)
+        {
+            continue;
         }
         alexandria::ACTMol actmol;
         actmol.Merge(&(*mp));

--- a/src/act/alexandria/tests/ACS-pg-gbham.xml
+++ b/src/act/alexandria/tests/ACS-pg-gbham.xml
@@ -4282,10 +4282,14 @@
     <parameterlist identifier="c2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.45" uncertainty="0" minimum="0.4" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="137977" uncertainty="0" minimum="137977" maximum="137977" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="c3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.45" uncertainty="0" minimum="0.4" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="137977" uncertainty="0" minimum="137977" maximum="137977" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="cl_s">
       <parameter type="alpha" unit="Angstrom3" value="2.75" uncertainty="0" minimum="1" maximum="4.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4298,6 +4302,8 @@
     <parameterlist identifier="h_s">
       <parameter type="alpha" unit="Angstrom3" value="0.55" uncertainty="0" minimum="0.1" maximum="1" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="161670" uncertainty="0" minimum="161670" maximum="161670" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="he_s">
       <parameter type="alpha" unit="Angstrom3" value="0.208" uncertainty="0" minimum="0.208" maximum="0.208" ntrain="0" mutability="Fixed" nonnegative="yes"/>
@@ -4338,6 +4344,8 @@
     <parameterlist identifier="o2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.45" uncertainty="0" minimum="0.4" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="137977" uncertainty="0" minimum="137977" maximum="137977" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="o3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.45" uncertainty="0" minimum="0.4" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>

--- a/src/act/alexandria/tests/ACS-pg.xml
+++ b/src/act/alexandria/tests/ACS-pg.xml
@@ -8532,6 +8532,8 @@
     <parameterlist identifier="c1_s">
       <parameter type="alpha" unit="Angstrom3" value="1.45" uncertainty="0" minimum="0.4" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="137977" uncertainty="0" minimum="137977" maximum="137977" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="c2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.45" uncertainty="0" minimum="0.4" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -8548,6 +8550,8 @@
     <parameterlist identifier="cl_s">
       <parameter type="alpha" unit="Angstrom3" value="2.75" uncertainty="0" minimum="1" maximum="4.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="72751.7" uncertainty="0" minimum="72751.7" maximum="72751.7" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="f_s">
       <parameter type="alpha" unit="Angstrom3" value="1.35" uncertainty="0" minimum="0.2" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -8602,7 +8606,7 @@
     <parameterlist identifier="o2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.45" uncertainty="0" minimum="0.4" maximum="2.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="137977" uncertainty="0" minimum="137977" maximum="137977" ntrain="1" mutability="Dependent" nonnegative="yes"/>
-      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="0" ntrain="0" mutability="Fixed" nonnegative="yes"/>
       <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="o3_s">
@@ -8630,10 +8634,14 @@
     <parameterlist identifier="s2_s">
       <parameter type="alpha" unit="Angstrom3" value="2" uncertainty="0" minimum="1" maximum="3" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="100034" uncertainty="0" minimum="100034" maximum="100034" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="s3_s">
       <parameter type="alpha" unit="Angstrom3" value="2" uncertainty="0" minimum="1" maximum="3" ntrain="0" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="100034" uncertainty="0" minimum="100034" maximum="100034" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="v2_s">
       <parameter type="alpha" unit="Angstrom3" value="0.3" uncertainty="0" minimum="0.1" maximum="0.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>

--- a/src/act/alexandria/tests/actmol_util.cpp
+++ b/src/act/alexandria/tests/actmol_util.cpp
@@ -71,6 +71,7 @@ void initACTMol(const char          *molname,
                                 &qtot, false, box, true);
         EXPECT_TRUE(readOK);
         MsgHandler msghandler;
+        msghandler.setPrintLevel(ACTStatus::Warning);
         // Uncomment in case of issues
         // msghandler.setACTStatus(ACTStatus::Debug);
 

--- a/src/act/alexandria/tests/molhandlerTest.cpp
+++ b/src/act/alexandria/tests/molhandlerTest.cpp
@@ -142,6 +142,7 @@ protected:
         auto forceComp = new ForceComputer(shellTolerance, shellMaxIter);
         std::vector<double>    qcustom;
         MsgHandler msghandler;
+        msghandler.setPrintLevel(ACTStatus::Warning);
         if (readOK)
         {
             for(auto &molprop: molprops)

--- a/src/act/alexandria/tests/openmmTest.cpp
+++ b/src/act/alexandria/tests/openmmTest.cpp
@@ -71,6 +71,7 @@ class OpenMMXmlTest : public gmx::test::CommandLineTestBase
         auto ifm   = gmx::test::TextFileMatch(gmx::test::ExactTextMatch()).createFileMatcher();
         gmx::test::TestFileManager tfm;
         MsgHandler                 msghandler; 
+        msghandler.setPrintLevel(ACTStatus::Warning);
         auto ff         = getForceField(forceField);
         double rmsToler = 0.0000001;
         auto fcomp = new ForceComputer(rmsToler, 25);

--- a/src/act/alexandria/topology.cpp
+++ b/src/act/alexandria/topology.cpp
@@ -1370,12 +1370,14 @@ void Topology::build(MsgHandler             *msghandler,
     makePairs(pd, InteractionType::VDW);
     makePairs(pd, InteractionType::ELECTROSTATICS);
     auto itqt = InteractionType::VDWCORRECTION;
-    if (pd->interactionPresent(itqt))
+    // If the interaction has no parameters even though it is present, ignore
+    if (pd->interactionPresent(itqt) && !pd->findForcesConst(itqt).empty())
     {
         makePairs(pd, itqt);
     }
     auto itic = InteractionType::INDUCTIONCORRECTION;
-    if (pd->interactionPresent(itic))
+    // If the interaction has no parameters even though it is present, ignore
+    if (pd->interactionPresent(itic) && !pd->findForcesConst(itic).empty())
     {
         makePairs(pd, itic);
     }
@@ -1588,7 +1590,7 @@ static void fillParams(MsgHandler                    *msghandler,
     std::string msg = potentialToString(fs.potential()) + " " + btype.id();
     if (ff.empty())
     {
-        msghandler->msg(ACTStatus::Warning, ACTMessage::MissingFFParameter, msg);
+        msghandler->msg(ACTStatus::Error, ACTMessage::MissingFFParameter, msg);
         return;
     }
     if (param->empty())
@@ -1610,7 +1612,7 @@ static void fillParams(MsgHandler                    *msghandler,
     if (found != independent)
     {
         msg += gmx::formatString(" found %d, expected %d independent parameters", found, independent);
-        msghandler->msg(ACTStatus::Warning, ACTMessage::MissingFFParameter, msg);
+        msghandler->msg(ACTStatus::Error, ACTMessage::MissingFFParameter, msg);
     }
 }
 
@@ -1693,7 +1695,7 @@ void Topology::fillParameters(MsgHandler        *msghandler,
             {
                 if (!msghandler->ok() && missing == missingParameters::Error)
                 {
-                    msghandler->msg(ACTStatus::Warning, ACTMessage::MissingFFParameter,
+                    msghandler->msg(ACTStatus::Error, ACTMessage::MissingFFParameter,
                                     gmx::formatString("Force field does not contain all %s parameters for %s, using zero's.", potentialToString(fs.potential()).c_str(), topID.id().c_str()));
                 }
                 topentry->setParams(param);

--- a/src/act/qgen/tests/ACM-pg.xml
+++ b/src/act/qgen/tests/ACM-pg.xml
@@ -4471,6 +4471,8 @@
     </parameterlist>
     <parameterlist identifier="I-_s">
       <parameter type="alpha" unit="Angstrom3" value="7.5" uncertainty="0" minimum="7.5" maximum="7.5" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="K+_s">
       <parameter type="alpha" unit="Angstrom3" value="0.81" uncertainty="0" minimum="0.81" maximum="0.81" ntrain="0" mutability="Fixed" nonnegative="yes"/>
@@ -4498,9 +4500,13 @@
     </parameterlist>
     <parameterlist identifier="c2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="c3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="cl_s">
       <parameter type="alpha" unit="Angstrom3" value="2.75" uncertainty="0" minimum="1" maximum="4.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4510,6 +4516,8 @@
     </parameterlist>
     <parameterlist identifier="h_s">
       <parameter type="alpha" unit="Angstrom3" value="0.5" uncertainty="0" minimum="0.1" maximum="0.9" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="he_s">
       <parameter type="alpha" unit="Angstrom3" value="1.05" uncertainty="0" minimum="0.1" maximum="2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4525,6 +4533,8 @@
     </parameterlist>
     <parameterlist identifier="n2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="n3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4540,9 +4550,13 @@
     </parameterlist>
     <parameterlist identifier="o2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="o3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="p1_s">
       <parameter type="alpha" unit="Angstrom3" value="2" uncertainty="0" minimum="1" maximum="3" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4552,6 +4566,8 @@
     </parameterlist>
     <parameterlist identifier="p3_s">
       <parameter type="alpha" unit="Angstrom3" value="2" uncertainty="0" minimum="1" maximum="3" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="s1_s">
       <parameter type="alpha" unit="Angstrom3" value="2" uncertainty="0" minimum="1" maximum="3" ntrain="0" mutability="Bounded" nonnegative="yes"/>

--- a/src/act/qgen/tests/ACS-pg.xml
+++ b/src/act/qgen/tests/ACS-pg.xml
@@ -4466,6 +4466,8 @@
     </parameterlist>
     <parameterlist identifier="I-_s">
       <parameter type="alpha" unit="Angstrom3" value="7.5" uncertainty="0" minimum="7.5" maximum="7.5" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="K+_s">
       <parameter type="alpha" unit="Angstrom3" value="0.81" uncertainty="0" minimum="0.81" maximum="0.81" ntrain="0" mutability="Fixed" nonnegative="yes"/>
@@ -4493,24 +4495,34 @@
     </parameterlist>
     <parameterlist identifier="c2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="c3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="cl_s">
       <parameter type="alpha" unit="Angstrom3" value="2.75" uncertainty="0" minimum="1" maximum="4.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="f_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="h_s">
       <parameter type="alpha" unit="Angstrom3" value="0.5" uncertainty="0" minimum="0.1" maximum="0.9" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="he_s">
       <parameter type="alpha" unit="Angstrom3" value="1.05" uncertainty="0" minimum="0.1" maximum="2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="i_s">
       <parameter type="alpha" unit="Angstrom3" value="7.5" uncertainty="0" minimum="5" maximum="10" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="kr_s">
       <parameter type="alpha" unit="Angstrom3" value="5.05" uncertainty="0" minimum="0.1" maximum="10" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4520,6 +4532,8 @@
     </parameterlist>
     <parameterlist identifier="n2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="n3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4535,9 +4549,13 @@
     </parameterlist>
     <parameterlist identifier="o2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="o3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="p1_s">
       <parameter type="alpha" unit="Angstrom3" value="2" uncertainty="0" minimum="1" maximum="3" ntrain="0" mutability="Bounded" nonnegative="yes"/>

--- a/src/act/qgen/tests/ACS-ps.xml
+++ b/src/act/qgen/tests/ACS-ps.xml
@@ -2641,6 +2641,8 @@
     <parameterlist identifier="f_s">
       <parameter type="alpha" unit="Angstrom3" value="1.25918" uncertainty="0" minimum="0.2" maximum="2.5" ntrain="2" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="110338" uncertainty="0" minimum="110338" maximum="110338" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="h1_s">
       <parameter type="alpha" unit="Angstrom3" value="0.505" uncertainty="0" minimum="0.01" maximum="1" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -2685,6 +2687,8 @@
     <parameterlist identifier="hf_s">
       <parameter type="alpha" unit="Angstrom3" value="0.172793" uncertainty="0" minimum="0.01" maximum="1" ntrain="2" mutability="Bounded" nonnegative="yes"/>
       <parameter type="kshell" unit="kJ/mol nm2" value="804057" uncertainty="0" minimum="804057" maximum="804057" ntrain="1" mutability="Dependent" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="hi_s">
       <parameter type="alpha" unit="Angstrom3" value="0.485321" uncertainty="0" minimum="0.01" maximum="1" ntrain="2" mutability="Bounded" nonnegative="yes"/>

--- a/src/act/qgen/tests/ESP-pg.xml
+++ b/src/act/qgen/tests/ESP-pg.xml
@@ -4397,9 +4397,13 @@
     </parameterlist>
     <parameterlist identifier="c2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="c3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="cl_s">
       <parameter type="alpha" unit="Angstrom3" value="2.75" uncertainty="0" minimum="1" maximum="4.5" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4409,6 +4413,8 @@
     </parameterlist>
     <parameterlist identifier="h_s">
       <parameter type="alpha" unit="Angstrom3" value="0.5" uncertainty="0" minimum="0.1" maximum="0.9" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="he_s">
       <parameter type="alpha" unit="Angstrom3" value="1.05" uncertainty="0" minimum="0.1" maximum="2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4424,6 +4430,8 @@
     </parameterlist>
     <parameterlist identifier="n2_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="n3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
@@ -4442,6 +4450,8 @@
     </parameterlist>
     <parameterlist identifier="o3_s">
       <parameter type="alpha" unit="Angstrom3" value="1.3" uncertainty="0" minimum="0.4" maximum="2.2" ntrain="0" mutability="Bounded" nonnegative="yes"/>
+      <parameter type="fchyper" unit="kJ/mol nm4" value="0" uncertainty="0" minimum="0" maximum="500000000" ntrain="0" mutability="Fixed" nonnegative="yes"/>
+      <parameter type="rhyper" unit="nm" value="0.02" uncertainty="0" minimum="0" maximum="0.05" ntrain="0" mutability="Fixed" nonnegative="yes"/>
     </parameterlist>
     <parameterlist identifier="p1_s">
       <parameter type="alpha" unit="Angstrom3" value="2" uncertainty="0" minimum="1" maximum="3" ntrain="0" mutability="Bounded" nonnegative="yes"/>

--- a/src/act/qgen/tests/interactionEnergyTest.cpp
+++ b/src/act/qgen/tests/interactionEnergyTest.cpp
@@ -168,6 +168,7 @@ protected:
             }
             mp_.Merge(&molprop);
             MsgHandler msghandler;
+            msghandler.setPrintLevel(ACTStatus::Warning);
             // Generate charges and topology
             mp_.GenerateTopology(&msghandler, pd, missingParameters::Ignore);
             if (!msghandler.ok())

--- a/src/act/qgen/tests/qgen_acmTest.cpp
+++ b/src/act/qgen/tests/qgen_acmTest.cpp
@@ -168,6 +168,7 @@ class AcmTest : public gmx::test::CommandLineTestBase
             }
             mp_.Merge(&molprop);
             MsgHandler msghandler;
+            msghandler.setPrintLevel(ACTStatus::Warning);
             // Uncomment in case of issues
             // msghandler.setACTStatus(ACTStatus::Debug);
             // Generate charges and topology

--- a/src/act/qgen/tests/qgen_respTest.cpp
+++ b/src/act/qgen/tests/qgen_respTest.cpp
@@ -122,6 +122,7 @@ protected:
         ForceField   *pd = getForceField(qdist);
         auto mp = readMolecule(pd);
         MsgHandler msghandler;
+        msghandler.setPrintLevel(ACTStatus::Warning);
         mp.GenerateTopology(&msghandler, pd, missingParameters::Ignore);
         EXPECT_TRUE(msghandler.ok());
         if (!msghandler.ok())
@@ -160,7 +161,7 @@ protected:
         EXPECT_TRUE(std::abs(qtotal) < 1e-3);
         char buf[256];
         snprintf(buf, sizeof(buf), "qtotValuesEqdModel_%s",
-                 chargeTypeName(ct).c_str());
+                  chargeTypeName(ct).c_str());
         checker_.checkSequence(qtotValues.begin(),
                                qtotValues.end(), buf);
     }


### PR DESCRIPTION
By making missing parameters an error we do not allow calculations to proceed with an incomplete force field. In practice this means topologies do not get created without support in the force field. It turns out that a lot of code just happily would use incorrect topology, now crashed when there was no topology. Therefore, this patch touches some of those routines dealing with topologies and also some broken input files in the tests.

Fixes #808