### PR TITLE
Removed superfluous checking for induction correction

### DIFF
--- a/src/act/alexandria/devcomputer.cpp
+++ b/src/act/alexandria/devcomputer.cpp
@@ -752,48 +752,10 @@ void ForceEnergyDevComputer::calcDeviation(MsgHandler                    *msghan
                     {
                         continue;
                     }
-                    if (iem.find(rms.second) == iem.end())
+                    auto myff = iem.find(rms.second);
+                    if (myff != iem.end())
                     {
-                        continue;
-                    }
-                    if (sumInductionTerms &&
-                        (eRMS::DeltaHF == rms.first || eRMS::Induction == rms.first))
-                    {
-                        if (eRMS::Induction == rms.first)
-                        {
-                            auto &find = iem.find(InteractionType::INDUCTION)->second;
-                            auto &fic  = iem.find(InteractionType::INDUCTIONCORRECTION)->second;
-                            if (fic.haveACT())
-                            {
-                                msghandler->msg(ACTStatus::Debug,
-                                                gmx::formatString("Energy Induction = %g, InductionCorrection = %g",
-                                                                  find.eact(), fic.eact()));
-                                find.setACT(find.eact() + fic.eact());
-                                fic.setACT(0);
-                            }
-                            if (find.haveQM() && find.haveACT())
-                            {
-                                // Difficult to make this fool-proof. If the data is not consistent
-                                // with the command-line options used, things may break.
-                                auto eqm  = find.eqm();
-                                auto eact = find.eact();
-#ifdef KKK
-                                if (fic.haveQM())
-                                {
-                                    eqm  += fic.eqm();
-                                }
-                                if (fic.haveACT())
-                                {
-                                    eact += fic.eact();
-                                }
-#endif
-                                ti->second.increase(weight, gmx::square(eqm-eact));
-                            }
-                        }
-                    }
-                    else
-                    {
-                        auto &ff  = iem.find(rms.second)->second;
+                        auto &ff = myff->second;
                         if (ff.haveQM() && ff.haveACT())
                         {
                             auto eqm  = ff.eqm();


### PR DESCRIPTION
Since the code to merge induction correction with induction now is in actmol.cpp, it was a bug to have it still in devcomputer.cpp.

Fixes #846