### PR TITLE
Clarified error message when cloning openbabel repo

### DIFF
--- a/src/act/python/install_act
+++ b/src/act/python/install_act
@@ -140,7 +140,7 @@ def install_openbabel(anonymous, clone, destination, prefix, build_type, CXX, CC
             swdir = "openbabel-" + oblatest[:-7]
         # See if we succeeded, if so let's go
         if not os.path.isdir(swdir):
-            sys.exit("No directory %s. You may want to use the '-clone_OB' flag" % swdir)
+            sys.exit("No directory %s. Failed to log in to github.com. You may want to use the '-anon' flag along with '-clone_OB'." % swdir)
 
     else:
         print("Will not clone or fetch openbabel again since directory %s exists." % swdir)


### PR DESCRIPTION
In function install_openbabel() the message on line 143 says "You may want to use the '-OB_flag'" when the user wants to clone open babel repo but is not logged in to git. I clarified that the user may want to add the -anon flag as well.