### PR TITLE
Added pillow package

### DIFF
--- a/ACT.yml
+++ b/ACT.yml
@@ -4,7 +4,7 @@ channels:
   - pytorch
   - defaults
 dependencies:
-  - Python>=3.8
+  - Python>=3.9
   - conda>=22.11.1
   - Matplotlib
   - pip>=21.0
@@ -15,5 +15,6 @@ dependencies:
   - SWIG>=4.0.2
   - Graphviz
   - openmpi>=5.0.5
+  - pillow>=11.3.0
   - pip:
     - PubChemPy


### PR DESCRIPTION
Added the pillow package to the conda environment file ACT.yml. Pillow contains the Python Imaging Library (PIL) required to run the GUI. This package also requires Python >= 3.9 so I changed this as well.