### PR TITLE
Added check whether exponent was updated.

### DIFF
--- a/src/act/alexandria/molgen.cpp
+++ b/src/act/alexandria/molgen.cpp
@@ -350,7 +350,7 @@ void MolGen::checkDataSufficiency(MsgHandler *msghandler,
                 continue;
             }
             auto forces    = pd->findForces(itype);
-            auto comb_rule = getCombinationRule(*forces);
+            auto comb_rule = forces->combinationRules();
             if (!comb_rule.empty())
             {
                 atomicItypes.push_back(itype);
@@ -414,7 +414,7 @@ void MolGen::checkDataSufficiency(MsgHandler *msghandler,
                         continue;
                     }
                     auto forces    = pd->findForces(itype);
-                    auto comb_rule = getCombinationRule(*forces);
+                    auto comb_rule = forces->combinationRules();
                     if (!comb_rule.empty() && optimize(itype))
                     {
                         // This is a hack to allow fitting of a whole matrix of Van der Waals parameters.

--- a/src/act/alexandria/optimizationindex.cpp
+++ b/src/act/alexandria/optimizationindex.cpp
@@ -50,14 +50,11 @@ void OptimizationIndex::findForceFieldParameter(ForceField *pd)
         {
             ffp_ = fs->findParameterType(parameterId_, parameterType_);
         }
-        else
+        else if (fs->combinationRuleExists(parameterId_.id()))
         {
             // Look in combination rules
-            if (fs->combinationRuleExists(parameterId_.id()))
-            {
-                auto pcr = fs->combinationRule(parameterId_.id());
-                ffp_ = pcr->ffpl();
-            }
+            auto pcr = fs->combinationRule(parameterId_.id());
+            ffp_ = pcr->ffpl();
         }
     }
     else if (pd->hasParticleType(particleType_))

--- a/src/act/alexandria/staticindividualinfo.cpp
+++ b/src/act/alexandria/staticindividualinfo.cpp
@@ -154,9 +154,12 @@ void StaticIndividualInfo::updateForceField(MsgHandler                *msghandle
             auto iType = optIndex_[n].iType();
             if (msghandler->debug())
             {
-                msghandler->writeDebug(gmx::formatString("Updating %s parameter %d (set size %lu) to %g\n",
+                msghandler->writeDebug(gmx::formatString("Updating %s parameter %d %s %s (set size %lu) to %g, was %g\n",
                                                          interactionTypeToString(iType).c_str(), n,
-                                                         mychanged.size(), bases[n]));
+                                                         optIndex_[n].parameterType().c_str(),
+                                                         optIndex_[n].parameterName().c_str(),
+                                                         mychanged.size(), bases[n],
+                                                         p->value()));
             }
             p->setValue(bases[n]);
             p->setUpdated(true);

--- a/src/act/forcefield/combruleutil.cpp
+++ b/src/act/forcefield/combruleutil.cpp
@@ -136,7 +136,7 @@ int CombRuleUtil::convert(ForceFieldParameterList *vdw)
         std::string crule("combination_rule");
         if (vdw->optionExists(crule))
         {
-            for(auto &crule : getCombinationRule(*vdw))
+            for(auto &crule : vdw->combinationRules())
             {
                 vdw->addCombinationRule(crule.first,
                                         combinationRuleName(crule.second.rule()),

--- a/src/act/forcefield/forcefield_parameterlist.cpp
+++ b/src/act/forcefield/forcefield_parameterlist.cpp
@@ -524,14 +524,4 @@ CommunicationStatus ForceFieldParameterList::Receive(const CommunicationRecord *
     return cs;
 }
 
-CombRuleSet getCombinationRule(const ForceFieldParameterList &vdw)
-{
-    std::string oldCombRule("combination_rule");
-    if (vdw.optionExists(oldCombRule))
-    {
-        GMX_THROW(gmx::InvalidInputError("Old style combination_rule not supported anymore"));
-    }
-    return vdw.combinationRules();
-}
-
 } // namespace

--- a/src/act/forcefield/forcefield_parameterlist.h
+++ b/src/act/forcefield/forcefield_parameterlist.h
@@ -352,12 +352,6 @@ class ForceFieldParameterList
     int counter_ = 0;
 };
 
-/*! \brief Extract a map of combination rules for each parameter
- * \param[in] vdw Van der Waals list of ff params
- * \return the map
- */
-CombRuleSet getCombinationRule(const ForceFieldParameterList &vdw);
-    
 } // namespace
 
 #endif

--- a/src/act/forcefield/generate_dependent.cpp
+++ b/src/act/forcefield/generate_dependent.cpp
@@ -49,8 +49,7 @@ static void generateParameterPairs(ForceField      *pd,
         return;
     }
     auto forcesVdw = pd->findForces(itype);
-    auto comb_rule = getCombinationRule(*forcesVdw);
-
+    auto comb_rule = forcesVdw->combinationRules();
     // We temporarily store the new parameters here
     ForceFieldParameterListMap *parm = forcesVdw->parameters();;
     
@@ -64,6 +63,7 @@ static void generateParameterPairs(ForceField      *pd,
         {
             continue;
         }
+        // Check whether the parameter for atom i has been updated
         auto &iparam = ivdw.second;
         bool iupdated = false;
         for(const auto &ip : iparam)
@@ -97,13 +97,20 @@ static void generateParameterPairs(ForceField      *pd,
                                    (ActParticle::Vsite == ptj && ActParticle::Atom == pti));
                 }
             }
+            // Check whether the parameter for atom j has been updated
             auto &jparam = jvdw.second;
             bool jupdated = false;
             for(const auto &jp : jparam)
             {
                 jupdated = jupdated || jp.second.updated();
             }
-            if (!(iupdated || jupdated || force))
+            // Check whether the combination rule was updated
+            bool crupdated = false;
+            for(const auto &cr : comb_rule)
+            {
+                crupdated = crupdated || cr.second.ffplConst().updated();
+            }
+            if (!(iupdated || jupdated || crupdated || force))
             {
                 continue;
             }


### PR DESCRIPTION
Without the check, the exponent was updated but the combination rules would not be executed, leading to constant pair parameters.

Also removed supefluous function.

Fixes #1307